### PR TITLE
chore: add examples migrator

### DIFF
--- a/examples-migrator/examples-migrator.js
+++ b/examples-migrator/examples-migrator.js
@@ -1,0 +1,57 @@
+const fs = require('fs-extra');
+const globby = require('globby');
+const path = require('path');
+const shell = require('shelljs');
+
+const EXAMPLES_PATH = path.join(__dirname, '/../../angular/aio/content/examples');
+const OLD_AIO_PATH = path.join(__dirname, '/../../angular.io/public/docs/_examples');
+const E2E_TEST_FILENAME = 'e2e-spec.ts';
+
+// Not really to ignore, but they need a different processing
+const SPECIAL_EXAMPLES = [
+  'cb-ts-to-js'
+].map(example => {
+  return `${OLD_AIO_PATH}/${example}`;
+});
+const EXAMPLES_TO_IGNORE = [
+  `${OLD_AIO_PATH}/homepage-*`
+]
+.concat(SPECIAL_EXAMPLES)
+.map(e => `!${e}`);
+
+console.log('Deleting examples...');
+shell.rm('-rf', EXAMPLES_PATH);
+
+let examplesPath = globby.sync([OLD_AIO_PATH + '/*', ...EXAMPLES_TO_IGNORE], { dot: true });
+
+console.log('Copying examples');
+examplesPath.map(example => {
+  const originalPath = example;
+  const name = example.split('/').pop();
+  const isDirectory = fs.lstatSync(example).isDirectory();
+
+  if (isDirectory) {
+    // not all examples have a ts folder, for example _boilerplate
+    if (fs.existsSync(path.join(example, '/ts'))) {
+      example = path.join(example, '/ts');
+    }
+
+    const dest = path.join(EXAMPLES_PATH, name);
+
+    fs.copySync(example, dest);
+
+    // There are also e2e specs to copy
+    try {
+      fs.copySync(path.join(originalPath, E2E_TEST_FILENAME), path.join(dest, E2E_TEST_FILENAME));
+    } catch (e) {
+    }
+
+  } else {
+    fs.copySync(originalPath, path.join(EXAMPLES_PATH, name));
+  }
+});
+
+SPECIAL_EXAMPLES.map(example => {
+  const name = example.split('/').pop();
+  fs.copySync(example, path.join(EXAMPLES_PATH, name));
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.ts",
   "scripts": {
     "start": "ts-node ./node_modules/.bin/dgeni ./index.ts",
-    "test": "mocha -R spec --compilers ts:ts-node/register"
+    "test": "mocha -R spec --compilers ts:ts-node/register",
+    "migrate-examples": "node examples-migrator/examples-migrator.js"
   },
   "repository": {},
   "license": "MIT",
@@ -14,12 +15,15 @@
     "@types/node": "^7.0.5",
     "chai": "^3.5.0",
     "dgeni": "0.4.7",
+    "fs-extra": "^2.1.2",
     "glob": "^7.1.1",
+    "globby": "^6.1.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "pug-lexer": "^3.0.0",
     "pug-parser": "^2.0.2",
     "pug-walk": "^1.1.1",
+    "shelljs": "^0.7.7",
     "ts-node": "^2.1.0",
     "tslint": "^4.4.2",
     "typescript": "^2.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,16 @@ any-promise@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -265,6 +275,13 @@ findup-sync@~0.3.0:
   dependencies:
     glob "~5.0.0"
 
+fs-extra@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -280,7 +297,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -300,6 +317,16 @@ glob@~5.0.0:
     minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 got@^5.0.0:
   version "5.7.1"
@@ -321,7 +348,7 @@ got@^5.0.0:
     unzip-response "^1.0.2"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -361,6 +388,10 @@ inherits@2, inherits@~2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+interpret@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -428,6 +459,12 @@ js-tokens@^3.0.0:
 json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 latest-version@^2.0.0:
   version "2.0.0"
@@ -601,6 +638,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -674,6 +715,12 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 registry-auth-token@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.1.0.tgz#997c08256e0c7999837b90e944db39d8a790276b"
@@ -692,7 +739,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-resolve@^1.1.7:
+resolve@^1.1.6, resolve@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
 
@@ -705,6 +752,14 @@ semver-diff@^2.0.0:
 semver@^5.0.3, semver@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+shelljs@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 slide@^1.1.5:
   version "1.1.6"


### PR DESCRIPTION
The plugin requires the `angular` and `angular.io` to be sibling folders with the `aio-migrator` to work.