### PR TITLE
feat(example-migration): use the .gitignore file to filter what we copy over

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,12 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceRoot}/examples-migrator/examples-migrator.js"
+    },
   {
     "type": "node",
     "request": "launch",

--- a/examples-migrator/gitignore
+++ b/examples-migrator/gitignore
@@ -1,5 +1,4 @@
 # _boilerplate files
-!_boilerplate/*
 **/src/styles.css
 **/src/systemjs-angular-loader.js
 **/src/systemjs.config.js
@@ -11,8 +10,9 @@
 **/karma.conf.js
 **/karma-test-shim.js
 **/browser-test-shim.js
+**/node_modules
 
-# example files
+# built files
 *.map
 _test-output
 protractor-helpers.js
@@ -20,3 +20,39 @@ protractor-helpers.js
 **/*.js
 **/ts/**/*.js
 **/js-es6*/**/*.js
+dist/
+
+# special
+!_boilerplate/
+!/*
+!systemjs.config.*.js
+!*.1.*
+!*.2.*
+!*.3.*
+
+# AngularJS files
+!**/*.ajs.js
+
+# aot
+**/*.ngfactory.ts
+**/*.ngsummary.json
+**/*.shim.ngstyle.ts
+**/*.metadata.json
+!aot/bs-config.json
+!aot/index.html
+!copy-dist-files.js
+!rollup-config.js
+
+# testing
+!testing/src/browser-test-shim.js
+!testing/karma*.js
+
+# TS to JS
+!cb-ts-to-js/js*/**/*.js
+
+# webpack
+!webpack/**/config/*.js
+!webpack/**/*webpack*.js
+
+# style-guide
+!style-guide/src/systemjs.custom.js

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "main": "index.ts",
   "scripts": {
-    "start": "ts-node ./node_modules/.bin/dgeni ./index.ts",
-    "test": "mocha -R spec --compilers ts:ts-node/register",
-    "migrate-examples": "node examples-migrator/examples-migrator.js"
+    "start": "yarn migrate-guides && yarn migrate-examples",
+    "migrate-guides": "ts-node ./node_modules/.bin/dgeni ./index.ts",
+    "migrate-examples": "node examples-migrator/examples-migrator.js",
+    "test": "yarn migrate-guides-test",
+    "migrate-guides-test": "mocha -R spec --compilers ts:ts-node/register"
   },
   "repository": {},
   "license": "MIT",
@@ -18,6 +20,7 @@
     "fs-extra": "^2.1.2",
     "glob": "^7.1.1",
     "globby": "^6.1.0",
+    "ignore": "^3.2.6",
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "pug-lexer": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,6 +370,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+ignore@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.6.tgz#26e8da0644be0bb4cb39516f6c79f0e0f4ffe48c"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
This has two benefits:

* we don't have to clean the angular.io repo every time we want to migrate
* we are proving our new gitignore against the real files