### PR TITLE
feat(migrator): move boilerplate to a tool folder

### DIFF
--- a/examples-migrator/gitignore
+++ b/examples-migrator/gitignore
@@ -23,7 +23,6 @@ protractor-helpers.js
 dist/
 
 # special
-!_boilerplate/
 !/*
 !systemjs.config.*.js
 !*.1.*


### PR DESCRIPTION
I decided to split "examples to delete" from "examples to ignore" so it is easier later to move the ignored one out.