### PR TITLE
chore: filter out plunker.no-link

### DIFF
--- a/examples-migrator/gitignore
+++ b/examples-migrator/gitignore
@@ -21,6 +21,7 @@ protractor-helpers.js
 **/ts/**/*.js
 **/js-es6*/**/*.js
 dist/
+plnkr.no-link.html
 
 # special
 !/*


### PR DESCRIPTION
This file is generated within each example to allow the author to run the example in plunker without having to fire the server or look into a different "hidden" folder.