### PR TITLE
chore: add a few more rules to the examples migrator

### DIFF
--- a/examples-migrator/examples-migrator.js
+++ b/examples-migrator/examples-migrator.js
@@ -74,7 +74,11 @@ boilerplate.forEach(oldPath => {
   fs.copySync(path.resolve(OLD_EXAMPLES_PATH, oldPath), path.resolve(BOILERPLATE_PATH, newPath));
 });
 
-// // Copy our custom gitignore and replace the other one
+// Copy our custom gitignore and replace the other one
 console.log('Replacing the .gitignore with our new one.')
 const gitignoreFile = fs.readFileSync(path.join(__dirname, 'gitignore'));
 fs.writeFileSync(path.join(NEW_EXAMPLES_PATH, '.gitignore'), gitignoreFile);
+
+// Special case for the styles.css of cli-quickstart
+const stylesCss = fs.readFileSync(path.join(BOILERPLATE_PATH, 'boilerplate/src/styles.css'));
+fs.writeFileSync(path.join(NEW_EXAMPLES_PATH, 'cli-quickstart/src/styles.css'));

--- a/examples-migrator/gitignore
+++ b/examples-migrator/gitignore
@@ -56,6 +56,7 @@ dist/
 
 # TS to JS
 !cb-ts-to-js/js*/**/*.js
+cb-ts-to-js/js*/**/system*.js
 
 # webpack
 !webpack/**/config/*.js


### PR DESCRIPTION
We were not leaving out the systemjs stuff inside those examples and they can't be there.

Also, even when `styles.css` is a boilerplate file, the `cli-quickstart` comes with a gitignore (the one you get with `ng new`) and that gitignores allows a `styles.css` in there. So what we are doing now is simply keeping the boilerplate `styles.css` there, that way we don't have it always as a pending change.